### PR TITLE
Add terrascan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           command: cd terraform/modules/member_account && terraform validate -check-variables=false
       - run:
           name: Install terrascan
-          command: pip install terrascan --user
+          command: sudo pip install terrascan
       - run:
           name: Perform static code analysis with terrascan
           command: terrascan -l terraform/modules/member_account

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,16 +2,28 @@ version: 2
 jobs:
   validate:
     docker:
-      - image: hashicorp/terraform
+      - image: circleci/python
     steps:
       - checkout
       - run:
+          name: Install Terraform
+          command: |
+            wget https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip
+            unzip terraform_0.11.7_linux_amd64.zip
+            sudo mv terraform /usr/local/bin/terraform
+          working_directory: /tmp
+      - run:
           name: Set up Terraform
           command: cd terraform/modules/member_account && terraform init -backend=false
-
       - run:
           name: Validate Terraform
           command: cd terraform/modules/member_account && terraform validate -check-variables=false
+      - run:
+          name: Install terrascan
+          command: pip install terrascan
+      - run:
+          name: Perform static code analysis with terrascan
+          command: terrascan -l terraform/modules/member_account
 
 workflows:
     version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           command: cd terraform/modules/member_account && terraform validate -check-variables=false
       - run:
           name: Install terrascan
-          command: pip install terrascan
+          command: pip install terrascan --user
       - run:
           name: Perform static code analysis with terrascan
           command: terrascan -l terraform/modules/member_account


### PR DESCRIPTION
- Add terrascan for static code analysis (Closes #2 )
- Uses circleci/python Docker image instead of hashicorp/terraform image
- Installs Terraform and Terrascan inside container