### PR TITLE
Adds iam role and policy for grace-inventory-lambda function

### DIFF
--- a/terraform/modules/member_account/iam_policies.tf
+++ b/terraform/modules/member_account/iam_policies.tf
@@ -53,6 +53,17 @@ resource "aws_iam_policy" "GRACE_tenant_View_Only_Policy3" {
   policy      = "${file("${path.module}/iam_policy_files/view_policy3.json")}"
 }
 
+resource "aws_iam_policy" "grace_inventory_lambda_iam_policy" {
+  count = "${var.create_iam_roles == "true" ? 1 : 0}"
+
+  provider = "aws.child"
+
+  name        = "grace_inventory_lambda"
+  path        = "/"
+  description = "Cross-account profile for AWS service inventory"
+  policy      = "${file("${path.module}/iam_policy_files/grace_inventory_lambda_policy.json")}"
+}
+
 resource "aws_iam_role_policy_attachment" "grace_tenant_admins_policy_attachment" {
   count = "${var.create_iam_roles == "true" ? 1 : 0}"
 
@@ -94,4 +105,13 @@ resource "aws_iam_role_policy_attachment" "grace_tenant_view_only_policy3_attach
 
   role       = "${aws_iam_role.tenant_view_only_role.name}"
   policy_arn = "${aws_iam_policy.GRACE_tenant_View_Only_Policy3.arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "grace_inventory_lambda_iam_role_policy_attachment" {
+  count = "${var.create_iam_roles == "true" ? 1 : 0}"
+
+  provider = "aws.child"
+
+  role       = "${aws_iam_role.grace_inventory_lambda_iam_role.name}"
+  policy_arn = "${aws_iam_policy.grace_inventory_lambda_iam_policy.arn}"
 }

--- a/terraform/modules/member_account/iam_policy_files/grace_inventory_lambda_policy.json
+++ b/terraform/modules/member_account/iam_policy_files/grace_inventory_lambda_policy.json
@@ -1,0 +1,25 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:DescribeImages",
+        "ec2:DescribeInstances",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSnapshots",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeVolumes",
+        "ec2:DescribeVpcs",
+        "s3:ListBuckets",
+        "s3:ListAllMyBuckets",
+        "s3:HeadBucket",
+        "iam:ListGroups",
+        "iam:ListPolicies",
+        "iam:ListRoles",
+        "iam:ListUsers",
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}

--- a/terraform/modules/member_account/iam_roles.tf
+++ b/terraform/modules/member_account/iam_roles.tf
@@ -66,3 +66,26 @@ resource "aws_iam_role" "tenant_view_only_role" {
 }
 EOF
 }
+
+resource "aws_iam_role" "grace_inventory_lambda_iam_role" {
+  count = "${var.create_iam_roles == "true" ? 1 : 0}"
+
+  provider = "aws.child"
+
+  name = "grace-inventory-lambda"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": ${jsonencode(concat(formatlist("arn:aws:iam::%s:user/%s", var.grace_monitoring_prod_account_id, "grace-inventory-lambda")))}
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}


### PR DESCRIPTION
Adds iam role and policy for [grace-inventory-lambda](https://github.com/GSA/grace-inventory-lambda) function to perform an inventory of AWS servcices in GRACE tenant accounts.